### PR TITLE
Chapter-seed sessions[] on 16 items (cache completion)

### DIFF
--- a/data/video/activeinferenceinstitute/Applied Active Inference Symposium/2022 Symposium on Robotics/metadata.json
+++ b/data/video/activeinferenceinstitute/Applied Active Inference Symposium/2022 Symposium on Robotics/metadata.json
@@ -24,7 +24,8 @@
   "zenodo": "https://zenodo.org/record/7402485",
   "enriched_from": [
     "coda",
-    "generated"
+    "generated",
+    "youtube"
   ],
   "parts": [
     {
@@ -36,6 +37,86 @@
       "video_id": "dTVHHenms_Y",
       "url": "https://www.youtube.com/watch?v=dTVHHenms_Y",
       "title": "Applied Active Inference Symposium — Robotics 2022 ~ 2nd Applied Active Inference Symposium, part 2"
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "zm2d9o5n0PU_sess01",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 2,
+      "session_name": "zm2d9o5n0PU_sess02",
+      "start": "0:03:46",
+      "title": "Tim Schneider \"Active Inference for Robotic Manipulation\""
+    },
+    {
+      "index": 3,
+      "session_name": "zm2d9o5n0PU_sess03",
+      "start": "0:32:10",
+      "title": "Tim Verbelen \"Robots Modeling the World from Pixels using Deep Active Inference\""
+    },
+    {
+      "index": 4,
+      "session_name": "zm2d9o5n0PU_sess04",
+      "start": "1:01:10",
+      "title": "Ben White \"Artificial Empathy: Active Inference and Collective Intelligence\""
+    },
+    {
+      "index": 5,
+      "session_name": "zm2d9o5n0PU_sess05",
+      "start": "1:34:04",
+      "title": "Noor Sajid \"Learning agent preferences\""
+    },
+    {
+      "index": 6,
+      "session_name": "zm2d9o5n0PU_sess06",
+      "start": "2:04:13",
+      "title": "Wen-Hua Chen \"Dual Control for Exploitation and Exploration and its Applications in Robotic Autonomous Search\""
+    },
+    {
+      "index": 7,
+      "session_name": "zm2d9o5n0PU_sess07",
+      "start": "2:39:49",
+      "title": "Roundtable with Wen-Hua Chen & Daniel Friedman"
+    },
+    {
+      "index": 8,
+      "session_name": "dTVHHenms_Y_sess08",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 9,
+      "session_name": "dTVHHenms_Y_sess09",
+      "start": "0:01:48",
+      "title": "Bruno Lara \"Prediction error dynamics: a proof of concept implementation.\""
+    },
+    {
+      "index": 10,
+      "session_name": "dTVHHenms_Y_sess10",
+      "start": "0:32:44",
+      "title": "Matt Brown \"Real-time Robotic Control through Embodied Homeostatic Feedback\""
+    },
+    {
+      "index": 11,
+      "session_name": "dTVHHenms_Y_sess11",
+      "start": "1:05:44",
+      "title": "Adam Safron \"Generalized Simultaneous Localization and Mapping (G-SLAM) as unification framework for natural and artificial intelligences\""
+    },
+    {
+      "index": 12,
+      "session_name": "dTVHHenms_Y_sess12",
+      "start": "1:42:12",
+      "title": "JF Cloutier \"Towards a symbolic implementation of Active Inference for Lego robots\""
+    },
+    {
+      "index": 13,
+      "session_name": "dTVHHenms_Y_sess13",
+      "start": "2:23:13",
+      "title": "Roundtable with Jakub Smekal, Bruno Lara, Adam Safron, JF Cloutier Karl Friston"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/GuestStream/GuestStream_023/metadata.json
+++ b/data/video/activeinferenceinstitute/GuestStream/GuestStream_023/metadata.json
@@ -18,13 +18,76 @@
   "paper_title": "On Bayesian Mechanics: A Physics of and by Beliefs",
   "enriched_from": [
     "coda",
-    "generated"
+    "generated",
+    "youtube"
   ],
   "parts": [
     {
       "video_id": "igY9iyowesc",
       "url": "https://www.youtube.com/watch?v=igY9iyowesc",
       "title": "ActInf GuestStream #023.1 ~ Maxwell Ramstead, Dalton Sakthivadivel, et al."
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "igY9iyowesc_sess01",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 2,
+      "session_name": "igY9iyowesc_sess02",
+      "start": "0:27:09",
+      "title": "Section One Is the Introduction"
+    },
+    {
+      "index": 3,
+      "session_name": "igY9iyowesc_sess03",
+      "start": "0:46:56",
+      "title": "The Three Faces of Bayesian Mechanics"
+    },
+    {
+      "index": 4,
+      "session_name": "igY9iyowesc_sess04",
+      "start": "0:57:07",
+      "title": "Free Energy Principle"
+    },
+    {
+      "index": 5,
+      "session_name": "igY9iyowesc_sess05",
+      "start": "1:02:32",
+      "title": "What Is a Gauge Theory"
+    },
+    {
+      "index": 6,
+      "session_name": "igY9iyowesc_sess06",
+      "start": "1:15:47",
+      "title": "Active Inference Framework"
+    },
+    {
+      "index": 7,
+      "session_name": "igY9iyowesc_sess07",
+      "start": "1:24:38",
+      "title": "The Free Energy Principle"
+    },
+    {
+      "index": 8,
+      "session_name": "igY9iyowesc_sess08",
+      "start": "1:25:35",
+      "title": "Nested Representationalism"
+    },
+    {
+      "index": 9,
+      "session_name": "igY9iyowesc_sess09",
+      "start": "1:28:52",
+      "title": "Maximum Entropy Inference"
+    },
+    {
+      "index": 10,
+      "session_name": "igY9iyowesc_sess10",
+      "start": "1:37:07",
+      "title": "What Does It Mean To Have a Non-Stationary Density over Paths"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/GuestStream/GuestStream_025/metadata.json
+++ b/data/video/activeinferenceinstitute/GuestStream/GuestStream_025/metadata.json
@@ -17,13 +17,118 @@
   "paper_title": "Autistic-Like Traits and Positive Schizotypy as Diametric Specializations of the Predictive Mind",
   "enriched_from": [
     "coda",
-    "generated"
+    "generated",
+    "youtube"
   ],
   "parts": [
     {
       "video_id": "ZYhrtsyzS_w",
       "url": "https://www.youtube.com/watch?v=ZYhrtsyzS_w",
       "title": "ActInf GuestStream #025.1 ~ \"Autistic-Like Traits, Positive Schizotypy, Predictive Mind”"
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "ZYhrtsyzS_w_sess01",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 2,
+      "session_name": "ZYhrtsyzS_w_sess02",
+      "start": "0:02:13",
+      "title": "The Diametric Model of Autism and Psychosis"
+    },
+    {
+      "index": 3,
+      "session_name": "ZYhrtsyzS_w_sess03",
+      "start": "0:04:38",
+      "title": "Evidence for the Diametric Model"
+    },
+    {
+      "index": 4,
+      "session_name": "ZYhrtsyzS_w_sess04",
+      "start": "0:04:55",
+      "title": "Paternally Expressed Genes Promote Autism"
+    },
+    {
+      "index": 5,
+      "session_name": "ZYhrtsyzS_w_sess05",
+      "start": "0:07:07",
+      "title": "Autistic like Traits"
+    },
+    {
+      "index": 6,
+      "session_name": "ZYhrtsyzS_w_sess06",
+      "start": "0:07:50",
+      "title": "The Precision Weighting of Sensory Input Hypothesis"
+    },
+    {
+      "index": 7,
+      "session_name": "ZYhrtsyzS_w_sess07",
+      "start": "0:10:36",
+      "title": "Differences along the Autism Schizotype Continuum"
+    },
+    {
+      "index": 8,
+      "session_name": "ZYhrtsyzS_w_sess08",
+      "start": "0:11:32",
+      "title": "Rubber Hand Illusion"
+    },
+    {
+      "index": 9,
+      "session_name": "ZYhrtsyzS_w_sess09",
+      "start": "0:14:07",
+      "title": "Imagination"
+    },
+    {
+      "index": 10,
+      "session_name": "ZYhrtsyzS_w_sess10",
+      "start": "0:16:14",
+      "title": "How Can the Psi Hypothesis Account for this"
+    },
+    {
+      "index": 11,
+      "session_name": "ZYhrtsyzS_w_sess11",
+      "start": "0:22:51",
+      "title": "Apophinia"
+    },
+    {
+      "index": 12,
+      "session_name": "ZYhrtsyzS_w_sess12",
+      "start": "0:27:48",
+      "title": "Evolutionary Implications the Autism Schizotypal Continuum"
+    },
+    {
+      "index": 13,
+      "session_name": "ZYhrtsyzS_w_sess13",
+      "start": "0:35:15",
+      "title": "Imprinted Genes"
+    },
+    {
+      "index": 14,
+      "session_name": "ZYhrtsyzS_w_sess14",
+      "start": "0:40:30",
+      "title": "The Engineers of Jihad"
+    },
+    {
+      "index": 15,
+      "session_name": "ZYhrtsyzS_w_sess15",
+      "start": "0:51:50",
+      "title": "What Are the Varieties of the Attention Experience"
+    },
+    {
+      "index": 16,
+      "session_name": "ZYhrtsyzS_w_sess16",
+      "start": "0:57:27",
+      "title": "How Do We Shape Our Attention To Be Who We Want To Be"
+    },
+    {
+      "index": 17,
+      "session_name": "ZYhrtsyzS_w_sess17",
+      "start": "1:02:22",
+      "title": "Reciprocal Narrowing"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/GuestStream/GuestStream_026/metadata.json
+++ b/data/video/activeinferenceinstitute/GuestStream/GuestStream_026/metadata.json
@@ -20,13 +20,46 @@
   "paper_title": "From Users to (Sense)Makers: On the Pivotal Role of Stigmergic Social Annotation in the Quest for Collective Sensemaking",
   "enriched_from": [
     "coda",
-    "generated"
+    "generated",
+    "youtube"
   ],
   "parts": [
     {
       "video_id": "J7cu4slfIBA",
       "url": "https://www.youtube.com/watch?v=J7cu4slfIBA",
       "title": "ActInf GuestStream #026.1 ~ \"From Users to (Sense)Makers\" and Stigmergic Annotation"
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "J7cu4slfIBA_sess01",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 2,
+      "session_name": "J7cu4slfIBA_sess02",
+      "start": "0:29:14",
+      "title": "A Decentralized Maker Centric Ecosystem"
+    },
+    {
+      "index": 3,
+      "session_name": "J7cu4slfIBA_sess03",
+      "start": "1:08:39",
+      "title": "What Is Attention in Active Inference"
+    },
+    {
+      "index": 4,
+      "session_name": "J7cu4slfIBA_sess04",
+      "start": "1:09:39",
+      "title": "Where and How Is Active Inference Being Applied"
+    },
+    {
+      "index": 5,
+      "session_name": "J7cu4slfIBA_sess05",
+      "start": "1:28:40",
+      "title": "Content Accessibility"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/GuestStream/GuestStream_039/metadata.json
+++ b/data/video/activeinferenceinstitute/GuestStream/GuestStream_039/metadata.json
@@ -19,13 +19,154 @@
   "paper_title": "Sources of Richness and Ineffability for Phenomenally Conscious States",
   "enriched_from": [
     "coda",
-    "generated"
+    "generated",
+    "youtube"
   ],
   "parts": [
     {
       "video_id": "jXEJO_5g0ho",
       "url": "https://www.youtube.com/watch?v=jXEJO_5g0ho",
       "title": "ActInf GuestStream #039.1 ~ Sources of Richness and Ineffability for Phenomenally Conscious States"
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "jXEJO_5g0ho_sess01",
+      "start": "0:00:00",
+      "title": "Introduction"
+    },
+    {
+      "index": 2,
+      "session_name": "jXEJO_5g0ho_sess02",
+      "start": "0:02:20",
+      "title": "The Hard Problem of Consciousness"
+    },
+    {
+      "index": 3,
+      "session_name": "jXEJO_5g0ho_sess03",
+      "start": "0:04:28",
+      "title": "The Knowledge Argument"
+    },
+    {
+      "index": 4,
+      "session_name": "jXEJO_5g0ho_sess04",
+      "start": "0:06:38",
+      "title": "Presentation Structure"
+    },
+    {
+      "index": 5,
+      "session_name": "jXEJO_5g0ho_sess05",
+      "start": "0:08:10",
+      "title": "Why Richness and Ineffability"
+    },
+    {
+      "index": 6,
+      "session_name": "jXEJO_5g0ho_sess06",
+      "start": "0:11:17",
+      "title": "State Attracters"
+    },
+    {
+      "index": 7,
+      "session_name": "jXEJO_5g0ho_sess07",
+      "start": "0:15:21",
+      "title": "Global Workspace Theory"
+    },
+    {
+      "index": 8,
+      "session_name": "jXEJO_5g0ho_sess08",
+      "start": "0:17:55",
+      "title": "Other Related Arguments"
+    },
+    {
+      "index": 9,
+      "session_name": "jXEJO_5g0ho_sess09",
+      "start": "0:18:52",
+      "title": "Information Theory"
+    },
+    {
+      "index": 10,
+      "session_name": "jXEJO_5g0ho_sess10",
+      "start": "0:22:42",
+      "title": "Source of Ineffability"
+    },
+    {
+      "index": 11,
+      "session_name": "jXEJO_5g0ho_sess11",
+      "start": "0:28:33",
+      "title": "Recap"
+    },
+    {
+      "index": 12,
+      "session_name": "jXEJO_5g0ho_sess12",
+      "start": "0:29:09",
+      "title": "Conscious Experience and Working Memory"
+    },
+    {
+      "index": 13,
+      "session_name": "jXEJO_5g0ho_sess13",
+      "start": "0:30:27",
+      "title": "Generalizing Ineffability"
+    },
+    {
+      "index": 14,
+      "session_name": "jXEJO_5g0ho_sess14",
+      "start": "0:30:31",
+      "title": "Pathways"
+    },
+    {
+      "index": 15,
+      "session_name": "jXEJO_5g0ho_sess15",
+      "start": "0:33:00",
+      "title": "Interpersonal Communication"
+    },
+    {
+      "index": 16,
+      "session_name": "jXEJO_5g0ho_sess16",
+      "start": "0:33:35",
+      "title": "Congo of Complexity"
+    },
+    {
+      "index": 17,
+      "session_name": "jXEJO_5g0ho_sess17",
+      "start": "0:38:00",
+      "title": "Results"
+    },
+    {
+      "index": 18,
+      "session_name": "jXEJO_5g0ho_sess18",
+      "start": "0:40:43",
+      "title": "Cognitive dissimilarity"
+    },
+    {
+      "index": 19,
+      "session_name": "jXEJO_5g0ho_sess19",
+      "start": "0:41:54",
+      "title": "Theory of Mind"
+    },
+    {
+      "index": 20,
+      "session_name": "jXEJO_5g0ho_sess20",
+      "start": "0:43:33",
+      "title": "Grounding Problem"
+    },
+    {
+      "index": 21,
+      "session_name": "jXEJO_5g0ho_sess21",
+      "start": "0:45:39",
+      "title": "Observations of Spelling"
+    },
+    {
+      "index": 22,
+      "session_name": "jXEJO_5g0ho_sess22",
+      "start": "0:49:46",
+      "title": "Future Directions"
+    },
+    {
+      "index": 23,
+      "session_name": "jXEJO_5g0ho_sess23",
+      "start": "0:51:57",
+      "title": "Opening Remarks"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/Livestream/LiveStream_045/metadata.json
+++ b/data/video/activeinferenceinstitute/Livestream/LiveStream_045/metadata.json
@@ -22,7 +22,8 @@
   "enriched_from": [
     "coda",
     "generated",
-    "db"
+    "db",
+    "youtube"
   ],
   "parts": [
     {
@@ -48,6 +49,278 @@
       "date": "2022-06-08",
       "slides_url": "https://docs.google.com/presentation/d/1645pSF7P5ag4QWUiC8X2RM5GFSgX_qfEFSuu1PI801U/edit?usp=sharing",
       "slides_label": "#045.1/2"
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "9MQQKaKEXs0_sess01",
+      "start": "0:00:00",
+      "title": "Introduction"
+    },
+    {
+      "index": 2,
+      "session_name": "9MQQKaKEXs0_sess02",
+      "start": "0:00:40",
+      "title": "Welcome"
+    },
+    {
+      "index": 3,
+      "session_name": "9MQQKaKEXs0_sess03",
+      "start": "0:01:15",
+      "title": "Title"
+    },
+    {
+      "index": 4,
+      "session_name": "9MQQKaKEXs0_sess04",
+      "start": "0:02:27",
+      "title": "Introducing Daniel"
+    },
+    {
+      "index": 5,
+      "session_name": "9MQQKaKEXs0_sess05",
+      "start": "0:03:06",
+      "title": "Questions"
+    },
+    {
+      "index": 6,
+      "session_name": "9MQQKaKEXs0_sess06",
+      "start": "0:04:46",
+      "title": "Aims and claims"
+    },
+    {
+      "index": 7,
+      "session_name": "9MQQKaKEXs0_sess07",
+      "start": "0:06:52",
+      "title": "Abstract"
+    },
+    {
+      "index": 8,
+      "session_name": "9MQQKaKEXs0_sess08",
+      "start": "0:08:32",
+      "title": "Road Map"
+    },
+    {
+      "index": 9,
+      "session_name": "9MQQKaKEXs0_sess09",
+      "start": "0:11:32",
+      "title": "Keywords"
+    },
+    {
+      "index": 10,
+      "session_name": "9MQQKaKEXs0_sess10",
+      "start": "0:11:45",
+      "title": "Bayesian analysis"
+    },
+    {
+      "index": 11,
+      "session_name": "9MQQKaKEXs0_sess11",
+      "start": "0:14:13",
+      "title": "Nonequilibrium"
+    },
+    {
+      "index": 12,
+      "session_name": "9MQQKaKEXs0_sess12",
+      "start": "0:17:31",
+      "title": "Selforganization"
+    },
+    {
+      "index": 13,
+      "session_name": "9MQQKaKEXs0_sess13",
+      "start": "0:20:26",
+      "title": "Variational inference"
+    },
+    {
+      "index": 14,
+      "session_name": "9MQQKaKEXs0_sess14",
+      "start": "0:23:33",
+      "title": "Markov blanket"
+    },
+    {
+      "index": 15,
+      "session_name": "9MQQKaKEXs0_sess15",
+      "start": "0:26:09",
+      "title": "Section 1 Introduction"
+    },
+    {
+      "index": 16,
+      "session_name": "9MQQKaKEXs0_sess16",
+      "start": "0:30:18",
+      "title": "What is the Free Energy Principle"
+    },
+    {
+      "index": 17,
+      "session_name": "9MQQKaKEXs0_sess17",
+      "start": "0:34:52",
+      "title": "Is the FEP useful"
+    },
+    {
+      "index": 18,
+      "session_name": "9MQQKaKEXs0_sess18",
+      "start": "0:39:10",
+      "title": "Roadmap"
+    },
+    {
+      "index": 19,
+      "session_name": "9MQQKaKEXs0_sess19",
+      "start": "0:39:38",
+      "title": "Systems states and fluctuations"
+    },
+    {
+      "index": 20,
+      "session_name": "9MQQKaKEXs0_sess20",
+      "start": "0:48:25",
+      "title": "Path of least action"
+    },
+    {
+      "index": 21,
+      "session_name": "9MQQKaKEXs0_sess21",
+      "start": "0:51:06",
+      "title": "Formalisms"
+    },
+    {
+      "index": 22,
+      "session_name": "9MQQKaKEXs0_sess22",
+      "start": "0:52:45",
+      "title": "Steady States and Nonequilibrium"
+    },
+    {
+      "index": 23,
+      "session_name": "9MQQKaKEXs0_sess23",
+      "start": "0:55:32",
+      "title": "Stochastic Chaos and Markov Blankets"
+    },
+    {
+      "index": 24,
+      "session_name": "V0l9fOJgbtc_sess24",
+      "start": "0:00:00",
+      "title": "Introduction"
+    },
+    {
+      "index": 25,
+      "session_name": "V0l9fOJgbtc_sess25",
+      "start": "0:04:50",
+      "title": "The simpler one"
+    },
+    {
+      "index": 26,
+      "session_name": "V0l9fOJgbtc_sess26",
+      "start": "0:06:20",
+      "title": "Layout and roadmap"
+    },
+    {
+      "index": 27,
+      "session_name": "V0l9fOJgbtc_sess27",
+      "start": "0:10:20",
+      "title": "A burning question"
+    },
+    {
+      "index": 28,
+      "session_name": "V0l9fOJgbtc_sess28",
+      "start": "0:16:55",
+      "title": "Hidden causes"
+    },
+    {
+      "index": 29,
+      "session_name": "V0l9fOJgbtc_sess29",
+      "start": "0:19:50",
+      "title": "Utility of the FEP"
+    },
+    {
+      "index": 30,
+      "session_name": "V0l9fOJgbtc_sess30",
+      "start": "0:24:35",
+      "title": "What is variational inference"
+    },
+    {
+      "index": 31,
+      "session_name": "V0l9fOJgbtc_sess31",
+      "start": "0:30:25",
+      "title": "Is this all in the service of homeostasis"
+    },
+    {
+      "index": 32,
+      "session_name": "V0l9fOJgbtc_sess32",
+      "start": "0:34:55",
+      "title": "What is homeostasis"
+    },
+    {
+      "index": 33,
+      "session_name": "V0l9fOJgbtc_sess33",
+      "start": "0:37:25",
+      "title": "Generalized homeostasis"
+    },
+    {
+      "index": 34,
+      "session_name": "V0l9fOJgbtc_sess34",
+      "start": "0:38:55",
+      "title": "Generalized synchrony"
+    },
+    {
+      "index": 35,
+      "session_name": "V0l9fOJgbtc_sess35",
+      "start": "0:44:25",
+      "title": "Taylor expansion"
+    },
+    {
+      "index": 36,
+      "session_name": "V0l9fOJgbtc_sess36",
+      "start": "0:45:15",
+      "title": "Compactness"
+    },
+    {
+      "index": 37,
+      "session_name": "V0l9fOJgbtc_sess37",
+      "start": "0:50:00",
+      "title": "Social Thomas"
+    },
+    {
+      "index": 38,
+      "session_name": "V0l9fOJgbtc_sess38",
+      "start": "0:56:20",
+      "title": "Fast and slow"
+    },
+    {
+      "index": 39,
+      "session_name": "S5-jXzhiG18_sess39",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 40,
+      "session_name": "S5-jXzhiG18_sess40",
+      "start": "0:22:43",
+      "title": "How Can Seemingly Irrational Non-Optimal Behavior in some Organisms Be Accounted for in Active Inference"
+    },
+    {
+      "index": 41,
+      "session_name": "S5-jXzhiG18_sess41",
+      "start": "0:28:59",
+      "title": "The Complete Plus Theorem"
+    },
+    {
+      "index": 42,
+      "session_name": "S5-jXzhiG18_sess42",
+      "start": "0:31:44",
+      "title": "Bounded Rationality"
+    },
+    {
+      "index": 43,
+      "session_name": "S5-jXzhiG18_sess43",
+      "start": "1:02:37",
+      "title": "Generalized Synchrony"
+    },
+    {
+      "index": 44,
+      "session_name": "S5-jXzhiG18_sess44",
+      "start": "1:29:34",
+      "title": "Information Diagram"
+    },
+    {
+      "index": 45,
+      "session_name": "S5-jXzhiG18_sess45",
+      "start": "1:38:32",
+      "title": "Sentient Behavior and Action Observation"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/Livestream/LiveStream_046/metadata.json
+++ b/data/video/activeinferenceinstitute/Livestream/LiveStream_046/metadata.json
@@ -24,7 +24,8 @@
   "enriched_from": [
     "coda",
     "generated",
-    "db"
+    "db",
+    "youtube"
   ],
   "parts": [
     {
@@ -50,6 +51,80 @@
       "date": "2022-06-22",
       "slides_url": "https://docs.google.com/presentation/d/1GHDffM2pWGKUF_jz0F6SO74lykUEz5dVdolLzG6CefI/edit?usp=sharing",
       "slides_label": "#046.1/2"
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "skcKoCcAQJI_sess01",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 2,
+      "session_name": "skcKoCcAQJI_sess02",
+      "start": "0:05:55",
+      "title": "Big Question"
+    },
+    {
+      "index": 3,
+      "session_name": "skcKoCcAQJI_sess03",
+      "start": "0:10:55",
+      "title": "Aims of the paper."
+    },
+    {
+      "index": 4,
+      "session_name": "skcKoCcAQJI_sess04",
+      "start": "0:38:06",
+      "title": "From predictive coding to active inference"
+    },
+    {
+      "index": 5,
+      "session_name": "skcKoCcAQJI_sess05",
+      "start": "0:44:42",
+      "title": "Preliminary considerations"
+    },
+    {
+      "index": 6,
+      "session_name": "skcKoCcAQJI_sess06",
+      "start": "0:55:09",
+      "title": "Variational & Expected Free Energy considerations"
+    },
+    {
+      "index": 7,
+      "session_name": "JPsdk7pVa1I_sess07",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 8,
+      "session_name": "JPsdk7pVa1I_sess08",
+      "start": "0:00:44",
+      "title": "Welcome to the Active Inference Lab"
+    },
+    {
+      "index": 9,
+      "session_name": "JPsdk7pVa1I_sess09",
+      "start": "0:17:16",
+      "title": "Eliminativism"
+    },
+    {
+      "index": 10,
+      "session_name": "JPsdk7pVa1I_sess10",
+      "start": "0:46:34",
+      "title": "Applications of the Active Inference Formalism"
+    },
+    {
+      "index": 11,
+      "session_name": "JPsdk7pVa1I_sess11",
+      "start": "1:18:24",
+      "title": "Direction of Fit"
+    },
+    {
+      "index": 12,
+      "session_name": "JPsdk7pVa1I_sess12",
+      "start": "1:35:21",
+      "title": "Joint Probability Density"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/Livestream/LiveStream_047/metadata.json
+++ b/data/video/activeinferenceinstitute/Livestream/LiveStream_047/metadata.json
@@ -22,7 +22,8 @@
   "enriched_from": [
     "coda",
     "generated",
-    "db"
+    "db",
+    "youtube"
   ],
   "parts": [
     {
@@ -48,6 +49,92 @@
       "date": "2022-08-17",
       "slides_url": "https://docs.google.com/presentation/d/1YL_Smp5er1E6348t81gFqW1Fo7n8PWF2_W5Ys4SG_v4/edit#slide=id.gc77d90b7ef_1_17",
       "slides_label": "#047.1/2"
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "WKjqw3My_xM_sess01",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 2,
+      "session_name": "WKjqw3My_xM_sess02",
+      "start": "0:16:01",
+      "title": "Paper Overviews"
+    },
+    {
+      "index": 3,
+      "session_name": "WKjqw3My_xM_sess03",
+      "start": "0:28:58",
+      "title": "Background in Context"
+    },
+    {
+      "index": 4,
+      "session_name": "WKjqw3My_xM_sess04",
+      "start": "0:43:11",
+      "title": "Abduction and Semiotics"
+    },
+    {
+      "index": 5,
+      "session_name": "WKjqw3My_xM_sess05",
+      "start": "0:46:18",
+      "title": "What Is Abductive Reasoning"
+    },
+    {
+      "index": 6,
+      "session_name": "WKjqw3My_xM_sess06",
+      "start": "0:46:34",
+      "title": "Generative Abduction and Selective Abduction"
+    },
+    {
+      "index": 7,
+      "session_name": "WKjqw3My_xM_sess07",
+      "start": "0:57:01",
+      "title": "Realism and Instrumentalism"
+    },
+    {
+      "index": 8,
+      "session_name": "WKjqw3My_xM_sess08",
+      "start": "1:12:47",
+      "title": "Section 3"
+    },
+    {
+      "index": 9,
+      "session_name": "WKjqw3My_xM_sess09",
+      "start": "1:33:44",
+      "title": "The Leading Principle of Active Inferences"
+    },
+    {
+      "index": 10,
+      "session_name": "riJYh87FPx4_sess10",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 11,
+      "session_name": "riJYh87FPx4_sess11",
+      "start": "0:01:57",
+      "title": "Introductions"
+    },
+    {
+      "index": 12,
+      "session_name": "riJYh87FPx4_sess12",
+      "start": "1:11:54",
+      "title": "Road and Path Metaphor"
+    },
+    {
+      "index": 13,
+      "session_name": "riJYh87FPx4_sess13",
+      "start": "1:22:29",
+      "title": "Why They Use Dynamical Systems Theory"
+    },
+    {
+      "index": 14,
+      "session_name": "riJYh87FPx4_sess14",
+      "start": "1:39:58",
+      "title": "Counterfactual Generation"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/Livestream/LiveStream_048/metadata.json
+++ b/data/video/activeinferenceinstitute/Livestream/LiveStream_048/metadata.json
@@ -24,7 +24,8 @@
   "enriched_from": [
     "coda",
     "generated",
-    "db"
+    "db",
+    "youtube"
   ],
   "parts": [
     {
@@ -50,6 +51,50 @@
       "date": "2022-09-14",
       "slides_url": "https://docs.google.com/presentation/d/1yjfToWX_zspCwZZ7x363hbyGBF3t72L5jvg5tis3cLY/edit?usp=sharing",
       "slides_label": "#048.1/2"
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "zqiZjjY9H7M_sess01",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 2,
+      "session_name": "zqiZjjY9H7M_sess02",
+      "start": "0:07:28",
+      "title": "Roadmap"
+    },
+    {
+      "index": 3,
+      "session_name": "zqiZjjY9H7M_sess03",
+      "start": "0:14:34",
+      "title": "Dynamical Systems Model"
+    },
+    {
+      "index": 4,
+      "session_name": "zqiZjjY9H7M_sess04",
+      "start": "0:33:38",
+      "title": "The Ecological Interpretation of Active Inference"
+    },
+    {
+      "index": 5,
+      "session_name": "zqiZjjY9H7M_sess05",
+      "start": "0:49:31",
+      "title": "Conclusion"
+    },
+    {
+      "index": 6,
+      "session_name": "zqiZjjY9H7M_sess06",
+      "start": "0:56:12",
+      "title": "Model of How To Frame Complex Ecosystems"
+    },
+    {
+      "index": 7,
+      "session_name": "zqiZjjY9H7M_sess07",
+      "start": "1:04:56",
+      "title": "Final Final Thoughts"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/Livestream/LiveStream_049/metadata.json
+++ b/data/video/activeinferenceinstitute/Livestream/LiveStream_049/metadata.json
@@ -21,7 +21,8 @@
   "enriched_from": [
     "coda",
     "generated",
-    "db"
+    "db",
+    "youtube"
   ],
   "parts": [
     {
@@ -47,6 +48,218 @@
       "date": "2022-10-12",
       "slides_url": "https://docs.google.com/presentation/d/1C_ghcJ_TlhAUEEkGnyc5KefSFXyDw5j5Qbp6-N6hkhY/edit?usp=sharing",
       "slides_label": "#049.1/2"
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "OtX2Fpzn7KA_sess01",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 2,
+      "session_name": "OtX2Fpzn7KA_sess02",
+      "start": "0:02:51",
+      "title": "Introductions and Warm-Ups"
+    },
+    {
+      "index": 3,
+      "session_name": "OtX2Fpzn7KA_sess03",
+      "start": "0:08:28",
+      "title": "What Is Bayesian Mechanics"
+    },
+    {
+      "index": 4,
+      "session_name": "OtX2Fpzn7KA_sess04",
+      "start": "0:08:35",
+      "title": "Relevance of Bayesian Mechanics"
+    },
+    {
+      "index": 5,
+      "session_name": "OtX2Fpzn7KA_sess05",
+      "start": "0:15:34",
+      "title": "Derivation of Classical Physics from the Principle of Constraint Maximum Entropy"
+    },
+    {
+      "index": 6,
+      "session_name": "OtX2Fpzn7KA_sess06",
+      "start": "0:17:31",
+      "title": "Introduction"
+    },
+    {
+      "index": 7,
+      "session_name": "OtX2Fpzn7KA_sess07",
+      "start": "0:18:07",
+      "title": "Section 4 Is a Question of Quantum Ontology"
+    },
+    {
+      "index": 8,
+      "session_name": "OtX2Fpzn7KA_sess08",
+      "start": "0:21:12",
+      "title": "Historical Perspectives"
+    },
+    {
+      "index": 9,
+      "session_name": "OtX2Fpzn7KA_sess09",
+      "start": "0:49:50",
+      "title": "Introduction of the Concept of Blanket Index"
+    },
+    {
+      "index": 10,
+      "session_name": "OtX2Fpzn7KA_sess10",
+      "start": "0:54:17",
+      "title": "Three Faces of Bayesian Mechanics"
+    },
+    {
+      "index": 11,
+      "session_name": "OtX2Fpzn7KA_sess11",
+      "start": "0:56:50",
+      "title": "The Dynamics of a System"
+    },
+    {
+      "index": 12,
+      "session_name": "OtX2Fpzn7KA_sess12",
+      "start": "1:01:26",
+      "title": "The Principle of Stationary Action"
+    },
+    {
+      "index": 13,
+      "session_name": "OtX2Fpzn7KA_sess13",
+      "start": "1:05:31",
+      "title": "Newtonian Mechanics"
+    },
+    {
+      "index": 14,
+      "session_name": "OtX2Fpzn7KA_sess14",
+      "start": "1:10:37",
+      "title": "James's Maximum Entropy Principle"
+    },
+    {
+      "index": 15,
+      "session_name": "OtX2Fpzn7KA_sess15",
+      "start": "1:12:34",
+      "title": "The Heisenberg's Uncertainty Principle"
+    },
+    {
+      "index": 16,
+      "session_name": "OtX2Fpzn7KA_sess16",
+      "start": "1:17:23",
+      "title": "Bayesian Mechanics"
+    },
+    {
+      "index": 17,
+      "session_name": "OtX2Fpzn7KA_sess17",
+      "start": "1:20:10",
+      "title": "The Constraints Maximum Entropy Principle"
+    },
+    {
+      "index": 18,
+      "session_name": "OtX2Fpzn7KA_sess18",
+      "start": "1:23:17",
+      "title": "Three Phases of Bayesian Mechanics"
+    },
+    {
+      "index": 19,
+      "session_name": "OtX2Fpzn7KA_sess19",
+      "start": "1:26:03",
+      "title": "Section 2 Classical Physics"
+    },
+    {
+      "index": 20,
+      "session_name": "OtX2Fpzn7KA_sess20",
+      "start": "1:31:48",
+      "title": "Mode Matching"
+    },
+    {
+      "index": 21,
+      "session_name": "OtX2Fpzn7KA_sess21",
+      "start": "1:33:59",
+      "title": "Mode Tracking"
+    },
+    {
+      "index": 22,
+      "session_name": "OtX2Fpzn7KA_sess22",
+      "start": "1:34:49",
+      "title": "Terminal Mode Matching"
+    },
+    {
+      "index": 23,
+      "session_name": "OtX2Fpzn7KA_sess23",
+      "start": "1:38:21",
+      "title": "Section Seven"
+    },
+    {
+      "index": 24,
+      "session_name": "dAtC-Enmc8M_sess24",
+      "start": "0:00:00",
+      "title": "Introduction"
+    },
+    {
+      "index": 25,
+      "session_name": "dAtC-Enmc8M_sess25",
+      "start": "0:01:45",
+      "title": "Introductions"
+    },
+    {
+      "index": 26,
+      "session_name": "dAtC-Enmc8M_sess26",
+      "start": "0:10:00",
+      "title": "Context"
+    },
+    {
+      "index": 27,
+      "session_name": "dAtC-Enmc8M_sess27",
+      "start": "0:10:30",
+      "title": "Dynamics Mechanics and Principles"
+    },
+    {
+      "index": 28,
+      "session_name": "dAtC-Enmc8M_sess28",
+      "start": "0:11:00",
+      "title": "Dynamics vs Mechanics"
+    },
+    {
+      "index": 29,
+      "session_name": "dAtC-Enmc8M_sess29",
+      "start": "0:12:40",
+      "title": "Mechanics"
+    },
+    {
+      "index": 30,
+      "session_name": "dAtC-Enmc8M_sess30",
+      "start": "0:25:00",
+      "title": "G Theory"
+    },
+    {
+      "index": 31,
+      "session_name": "dAtC-Enmc8M_sess31",
+      "start": "0:32:00",
+      "title": "Bayesian Mechanics"
+    },
+    {
+      "index": 32,
+      "session_name": "dAtC-Enmc8M_sess32",
+      "start": "0:37:49",
+      "title": "Notes"
+    },
+    {
+      "index": 33,
+      "session_name": "dAtC-Enmc8M_sess33",
+      "start": "0:40:34",
+      "title": "Classical Mechanics"
+    },
+    {
+      "index": 34,
+      "session_name": "dAtC-Enmc8M_sess34",
+      "start": "0:48:34",
+      "title": "Statistical Mechanics"
+    },
+    {
+      "index": 35,
+      "session_name": "dAtC-Enmc8M_sess35",
+      "start": "0:55:49",
+      "title": "Quantum Mechanics"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/MathStream/MathStream_004/metadata.json
+++ b/data/video/activeinferenceinstitute/MathStream/MathStream_004/metadata.json
@@ -17,13 +17,124 @@
   "github": "https://github.com/ActiveInferenceInstitute/ActiveInferenceJournal/tree/main/data/video/activeinferenceinstitute/MathStream/MathStream_004",
   "enriched_from": [
     "coda",
-    "generated"
+    "generated",
+    "youtube"
   ],
   "parts": [
     {
       "video_id": "aN1GXOZp6xY",
       "url": "https://www.youtube.com/watch?v=aN1GXOZp6xY",
       "title": "ActInf MathStream #004.1 ~ David Spivak"
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "aN1GXOZp6xY_sess01",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 2,
+      "session_name": "aN1GXOZp6xY_sess02",
+      "start": "0:02:44",
+      "title": "Applied Category Theory"
+    },
+    {
+      "index": 3,
+      "session_name": "aN1GXOZp6xY_sess03",
+      "start": "0:40:28",
+      "title": "Arrangements and Dynamics"
+    },
+    {
+      "index": 4,
+      "session_name": "aN1GXOZp6xY_sess04",
+      "start": "0:44:21",
+      "title": "Dynamical System"
+    },
+    {
+      "index": 5,
+      "session_name": "aN1GXOZp6xY_sess05",
+      "start": "0:45:53",
+      "title": "Digital Circuits and Control Systems"
+    },
+    {
+      "index": 6,
+      "session_name": "aN1GXOZp6xY_sess06",
+      "start": "0:47:53",
+      "title": "Control Systems"
+    },
+    {
+      "index": 7,
+      "session_name": "aN1GXOZp6xY_sess07",
+      "start": "0:50:46",
+      "title": "Deep Neural Networks"
+    },
+    {
+      "index": 8,
+      "session_name": "aN1GXOZp6xY_sess08",
+      "start": "0:50:55",
+      "title": "Dynamic Organizational Structure"
+    },
+    {
+      "index": 9,
+      "session_name": "aN1GXOZp6xY_sess09",
+      "start": "1:00:12",
+      "title": "Computational Boundary of the Self"
+    },
+    {
+      "index": 10,
+      "session_name": "aN1GXOZp6xY_sess10",
+      "start": "1:01:41",
+      "title": "Language of Category Theory"
+    },
+    {
+      "index": 11,
+      "session_name": "aN1GXOZp6xY_sess11",
+      "start": "1:02:47",
+      "title": "What Is the Application of Category Theory"
+    },
+    {
+      "index": 12,
+      "session_name": "aN1GXOZp6xY_sess12",
+      "start": "1:05:41",
+      "title": "Category Theory"
+    },
+    {
+      "index": 13,
+      "session_name": "aN1GXOZp6xY_sess13",
+      "start": "1:07:13",
+      "title": "Jeffrey Epstein"
+    },
+    {
+      "index": 14,
+      "session_name": "aN1GXOZp6xY_sess14",
+      "start": "1:29:36",
+      "title": "Is It Possible To Conceive a Level of Abstraction Even More Meta than Category Theory in Mathematics"
+    },
+    {
+      "index": 15,
+      "session_name": "aN1GXOZp6xY_sess15",
+      "start": "1:32:17",
+      "title": "What Does Nesting and Enclosure Mean"
+    },
+    {
+      "index": 16,
+      "session_name": "aN1GXOZp6xY_sess16",
+      "start": "1:32:56",
+      "title": "Physical Arrangement and Logical Arrangement"
+    },
+    {
+      "index": 17,
+      "session_name": "aN1GXOZp6xY_sess17",
+      "start": "1:35:49",
+      "title": "Layer of Temporal Nesting"
+    },
+    {
+      "index": 18,
+      "session_name": "aN1GXOZp6xY_sess18",
+      "start": "1:43:14",
+      "title": "Spike Time Dependent Plasticity"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/ModelStream/ModelStream_006/metadata.json
+++ b/data/video/activeinferenceinstitute/ModelStream/ModelStream_006/metadata.json
@@ -18,13 +18,154 @@
   "paper_title": "Branching Time Active Inference: the theory and its generality",
   "enriched_from": [
     "coda",
-    "generated"
+    "generated",
+    "youtube"
   ],
   "parts": [
     {
       "video_id": "xBKRLG97cz4",
       "url": "https://www.youtube.com/watch?v=xBKRLG97cz4",
       "title": "ActInf ModelStream #006.1 ~ \"Branching Time Active Inference: the theory and its generality\""
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "xBKRLG97cz4_sess01",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 2,
+      "session_name": "xBKRLG97cz4_sess02",
+      "start": "0:02:36",
+      "title": "Active Inference"
+    },
+    {
+      "index": 3,
+      "session_name": "xBKRLG97cz4_sess03",
+      "start": "0:05:03",
+      "title": "The Entropy of the Likelihood Mapping"
+    },
+    {
+      "index": 4,
+      "session_name": "xBKRLG97cz4_sess04",
+      "start": "0:06:31",
+      "title": "Exact Inference"
+    },
+    {
+      "index": 5,
+      "session_name": "xBKRLG97cz4_sess05",
+      "start": "0:11:22",
+      "title": "Practical Example"
+    },
+    {
+      "index": 6,
+      "session_name": "xBKRLG97cz4_sess06",
+      "start": "0:12:26",
+      "title": "Community Index"
+    },
+    {
+      "index": 7,
+      "session_name": "xBKRLG97cz4_sess07",
+      "start": "0:13:14",
+      "title": "Multi-Clarative Research"
+    },
+    {
+      "index": 8,
+      "session_name": "xBKRLG97cz4_sess08",
+      "start": "0:23:16",
+      "title": "What Is Bias and Filtering"
+    },
+    {
+      "index": 9,
+      "session_name": "xBKRLG97cz4_sess09",
+      "start": "0:26:16",
+      "title": "Definition of the Generality Model"
+    },
+    {
+      "index": 10,
+      "session_name": "xBKRLG97cz4_sess10",
+      "start": "0:26:46",
+      "title": "Performance"
+    },
+    {
+      "index": 11,
+      "session_name": "xBKRLG97cz4_sess11",
+      "start": "0:27:45",
+      "title": "What Is Belief Propagation"
+    },
+    {
+      "index": 12,
+      "session_name": "xBKRLG97cz4_sess12",
+      "start": "0:30:52",
+      "title": "Temporal Styles"
+    },
+    {
+      "index": 13,
+      "session_name": "xBKRLG97cz4_sess13",
+      "start": "0:32:48",
+      "title": "The Generative Model"
+    },
+    {
+      "index": 14,
+      "session_name": "xBKRLG97cz4_sess14",
+      "start": "0:37:38",
+      "title": "Expected Free Launch"
+    },
+    {
+      "index": 15,
+      "session_name": "xBKRLG97cz4_sess15",
+      "start": "0:40:31",
+      "title": "State Aggregation"
+    },
+    {
+      "index": 16,
+      "session_name": "xBKRLG97cz4_sess16",
+      "start": "0:45:36",
+      "title": "Add Transition"
+    },
+    {
+      "index": 17,
+      "session_name": "xBKRLG97cz4_sess17",
+      "start": "0:46:54",
+      "title": "Graphical User Interface"
+    },
+    {
+      "index": 18,
+      "session_name": "xBKRLG97cz4_sess18",
+      "start": "1:03:45",
+      "title": "Analysis of the Computational Complexity"
+    },
+    {
+      "index": 19,
+      "session_name": "xBKRLG97cz4_sess19",
+      "start": "1:07:03",
+      "title": "The Variational Distribution"
+    },
+    {
+      "index": 20,
+      "session_name": "xBKRLG97cz4_sess20",
+      "start": "1:14:28",
+      "title": "Conditional Probability Table"
+    },
+    {
+      "index": 21,
+      "session_name": "xBKRLG97cz4_sess21",
+      "start": "1:22:11",
+      "title": "Hierarchical Nesting of Models and Learning"
+    },
+    {
+      "index": 22,
+      "session_name": "xBKRLG97cz4_sess22",
+      "start": "1:22:16",
+      "title": "How Do Nesting and Learning Influence the Theoretical and the Realized Computational Complexity"
+    },
+    {
+      "index": 23,
+      "session_name": "xBKRLG97cz4_sess23",
+      "start": "1:31:26",
+      "title": "Belief Propagation Algorithm"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/ModelStream/ModelStream_007/metadata.json
+++ b/data/video/activeinferenceinstitute/ModelStream/ModelStream_007/metadata.json
@@ -29,7 +29,8 @@
   },
   "enriched_from": [
     "coda",
-    "generated"
+    "generated",
+    "youtube"
   ],
   "parts": [
     {
@@ -55,6 +56,134 @@
       "duration": 7721.0,
       "upload_date": "",
       "date": "2023-01-18"
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "uX8iSoDR83g_sess01",
+      "start": "0:00:00",
+      "title": "Introduction"
+    },
+    {
+      "index": 2,
+      "session_name": "uX8iSoDR83g_sess02",
+      "start": "0:00:35",
+      "title": "Welcome"
+    },
+    {
+      "index": 3,
+      "session_name": "uX8iSoDR83g_sess03",
+      "start": "0:02:18",
+      "title": "Installing pymdp"
+    },
+    {
+      "index": 4,
+      "session_name": "uX8iSoDR83g_sess04",
+      "start": "0:03:25",
+      "title": "Review"
+    },
+    {
+      "index": 5,
+      "session_name": "uX8iSoDR83g_sess05",
+      "start": "0:05:25",
+      "title": "Graphical Model"
+    },
+    {
+      "index": 6,
+      "session_name": "uX8iSoDR83g_sess06",
+      "start": "0:08:15",
+      "title": "Factorization"
+    },
+    {
+      "index": 7,
+      "session_name": "uX8iSoDR83g_sess07",
+      "start": "0:11:18",
+      "title": "State Space Representation"
+    },
+    {
+      "index": 8,
+      "session_name": "uX8iSoDR83g_sess08",
+      "start": "0:15:28",
+      "title": "Collab"
+    },
+    {
+      "index": 9,
+      "session_name": "uX8iSoDR83g_sess09",
+      "start": "0:19:53",
+      "title": "Hidden State Factors"
+    },
+    {
+      "index": 10,
+      "session_name": "uX8iSoDR83g_sess10",
+      "start": "0:24:48",
+      "title": "Unwrapped Representations"
+    },
+    {
+      "index": 11,
+      "session_name": "uX8iSoDR83g_sess11",
+      "start": "0:30:18",
+      "title": "QuestionsComments"
+    },
+    {
+      "index": 12,
+      "session_name": "uX8iSoDR83g_sess12",
+      "start": "0:40:48",
+      "title": "Feedback loops"
+    },
+    {
+      "index": 13,
+      "session_name": "uX8iSoDR83g_sess13",
+      "start": "0:41:48",
+      "title": "Graphs"
+    },
+    {
+      "index": 14,
+      "session_name": "uX8iSoDR83g_sess14",
+      "start": "0:45:48",
+      "title": "Why do you do that"
+    },
+    {
+      "index": 15,
+      "session_name": "uX8iSoDR83g_sess15",
+      "start": "0:46:48",
+      "title": "Endorsement comments"
+    },
+    {
+      "index": 16,
+      "session_name": "uX8iSoDR83g_sess16",
+      "start": "0:49:48",
+      "title": "Semimarkovian Dynamics"
+    },
+    {
+      "index": 17,
+      "session_name": "uX8iSoDR83g_sess17",
+      "start": "0:51:48",
+      "title": "Initial States"
+    },
+    {
+      "index": 18,
+      "session_name": "uX8iSoDR83g_sess18",
+      "start": "0:54:48",
+      "title": "Multiarm Bandit"
+    },
+    {
+      "index": 19,
+      "session_name": "uX8iSoDR83g_sess19",
+      "start": "0:55:48",
+      "title": "Observation Modalities"
+    },
+    {
+      "index": 20,
+      "session_name": "uX8iSoDR83g_sess20",
+      "start": "0:57:48",
+      "title": "Hidden State Factor Levels"
+    },
+    {
+      "index": 21,
+      "session_name": "uX8iSoDR83g_sess21",
+      "start": "0:58:48",
+      "title": "Choice Control State"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/Roundtable/Roundtable_2022.2/metadata.json
+++ b/data/video/activeinferenceinstitute/Roundtable/Roundtable_2022.2/metadata.json
@@ -15,13 +15,58 @@
   "enriched_from": [
     "coda",
     "db",
-    "generated"
+    "generated",
+    "youtube"
   ],
   "parts": [
     {
       "video_id": "2s27lSZDqGM",
       "url": "https://www.youtube.com/watch?v=2s27lSZDqGM",
       "title": "ActInfLab ~ 2022 Quarterly Roundtable #2"
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "2s27lSZDqGM_sess01",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 2,
+      "session_name": "2s27lSZDqGM_sess02",
+      "start": "0:05:02",
+      "title": "Updates on the Project Scale"
+    },
+    {
+      "index": 3,
+      "session_name": "2s27lSZDqGM_sess03",
+      "start": "0:15:40",
+      "title": "Education"
+    },
+    {
+      "index": 4,
+      "session_name": "2s27lSZDqGM_sess04",
+      "start": "0:23:27",
+      "title": "Active Entities"
+    },
+    {
+      "index": 5,
+      "session_name": "2s27lSZDqGM_sess05",
+      "start": "0:45:40",
+      "title": "Systems Thinking Summer Intensive"
+    },
+    {
+      "index": 6,
+      "session_name": "2s27lSZDqGM_sess06",
+      "start": "0:47:06",
+      "title": "Educational Activities"
+    },
+    {
+      "index": 7,
+      "session_name": "2s27lSZDqGM_sess07",
+      "start": "0:50:09",
+      "title": "Expanding and Scaling the Active Inference Journal"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/Roundtable/Roundtable_2022.3/metadata.json
+++ b/data/video/activeinferenceinstitute/Roundtable/Roundtable_2022.3/metadata.json
@@ -15,13 +15,40 @@
   "enriched_from": [
     "coda",
     "db",
-    "generated"
+    "generated",
+    "youtube"
   ],
   "parts": [
     {
       "video_id": "DJ9n6a8mMzM",
       "url": "https://www.youtube.com/watch?v=DJ9n6a8mMzM",
       "title": "Active Inference Institute ~ 2022 Quarterly Roundtable #3"
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "DJ9n6a8mMzM_sess01",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 2,
+      "session_name": "DJ9n6a8mMzM_sess02",
+      "start": "0:00:38",
+      "title": "Welcome to Active Inference Institute! The Active Inference Institute is dedicated to learning"
+    },
+    {
+      "index": 3,
+      "session_name": "DJ9n6a8mMzM_sess03",
+      "start": "0:07:20",
+      "title": "Institute Structure Learning"
+    },
+    {
+      "index": 4,
+      "session_name": "DJ9n6a8mMzM_sess04",
+      "start": "0:48:12",
+      "title": "What might a good understanding enable?"
     }
   ]
 }

--- a/data/video/activeinferenceinstitute/Twitter Spaces/TwitterSpaces_002/metadata.json
+++ b/data/video/activeinferenceinstitute/Twitter Spaces/TwitterSpaces_002/metadata.json
@@ -12,13 +12,40 @@
   "zenodo": "https://zenodo.org/record/7447924",
   "enriched_from": [
     "coda",
-    "generated"
+    "generated",
+    "youtube"
   ],
   "parts": [
     {
       "video_id": "Sb8A0jNzWPE",
       "url": "https://www.youtube.com/watch?v=Sb8A0jNzWPE",
       "title": "Active Inference ~ Twitter Spaces #002 ~ Web3 survive without cognitive modeling? 👀"
+    }
+  ],
+  "sessions": [
+    {
+      "index": 1,
+      "session_name": "Sb8A0jNzWPE_sess01",
+      "start": "0:00:00",
+      "title": "<Untitled Chapter 1>"
+    },
+    {
+      "index": 2,
+      "session_name": "Sb8A0jNzWPE_sess02",
+      "start": "0:01:08",
+      "title": "Description of Web3"
+    },
+    {
+      "index": 3,
+      "session_name": "Sb8A0jNzWPE_sess03",
+      "start": "0:08:38",
+      "title": "Top-Down Structural Modeling and the Bottom-Up Modeling"
+    },
+    {
+      "index": 4,
+      "session_name": "Sb8A0jNzWPE_sess04",
+      "start": "0:24:20",
+      "title": "Formalism of Active Inference"
     }
   ]
 }


### PR DESCRIPTION
Follow-up to #3: the chapter fetch completed its final stragglers (54 more videos; cache now 727/729, 267 with chapters — committed in Journal-Utilities). Seeds `sessions[]` on the 16 newly covered items. Generated with the hardened `enrich_metadata.py` from main; idempotent (re-apply = 0 changes); `validate_journal.py` PASS; indexes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NjFiMWkgrVy4foGF1Zbax