### PR TITLE
Add 6 new channel videos (July 2026 re-enumeration)

### DIFF
--- a/INDEX.json
+++ b/INDEX.json
@@ -1,7 +1,7 @@
 {
-  "count": 573,
-  "videos": 740,
-  "unique_videos": 736,
+  "count": 579,
+  "videos": 746,
+  "unique_videos": 742,
   "items": [
     {
       "path": "data/video/activeinferenceinstitute/ActiveInferAntStream/ActiveInferAntStream_001",
@@ -1577,6 +1577,15 @@
       "has_transcript": true
     },
     {
+      "path": "data/video/activeinferenceinstitute/GuestStream/GuestStream_128",
+      "series": "GuestStream",
+      "item": "GuestStream_128",
+      "parts": [
+        "vjtYYbO9jCY"
+      ],
+      "has_transcript": false
+    },
+    {
       "path": "data/video/activeinferenceinstitute/Insights/Insights_001",
       "series": "Insights",
       "item": "Insights_001",
@@ -3083,6 +3092,24 @@
       "has_transcript": true
     },
     {
+      "path": "data/video/activeinferenceinstitute/Other/FnYCaCkah4U",
+      "series": "Other",
+      "item": "FnYCaCkah4U",
+      "parts": [
+        "FnYCaCkah4U"
+      ],
+      "has_transcript": false
+    },
+    {
+      "path": "data/video/activeinferenceinstitute/Other/FtGnkRJwk6U",
+      "series": "Other",
+      "item": "FtGnkRJwk6U",
+      "parts": [
+        "FtGnkRJwk6U"
+      ],
+      "has_transcript": false
+    },
+    {
       "path": "data/video/activeinferenceinstitute/Other/GMqkygROLO4",
       "series": "Other",
       "item": "GMqkygROLO4",
@@ -3146,6 +3173,15 @@
       "has_transcript": true
     },
     {
+      "path": "data/video/activeinferenceinstitute/Other/MjeQeWeyYhE",
+      "series": "Other",
+      "item": "MjeQeWeyYhE",
+      "parts": [
+        "MjeQeWeyYhE"
+      ],
+      "has_transcript": false
+    },
+    {
       "path": "data/video/activeinferenceinstitute/Other/OCCIDeeKOMA",
       "series": "Other",
       "item": "OCCIDeeKOMA",
@@ -3190,6 +3226,15 @@
         "RDDfKm4yQIo"
       ],
       "has_transcript": true
+    },
+    {
+      "path": "data/video/activeinferenceinstitute/Other/SBCl8DeaJYU",
+      "series": "Other",
+      "item": "SBCl8DeaJYU",
+      "parts": [
+        "SBCl8DeaJYU"
+      ],
+      "has_transcript": false
     },
     {
       "path": "data/video/activeinferenceinstitute/Other/TOZp_XNYijQ",
@@ -3253,6 +3298,15 @@
         "UYD8CR_Xorg"
       ],
       "has_transcript": true
+    },
+    {
+      "path": "data/video/activeinferenceinstitute/Other/V46B4Xy1PeQ",
+      "series": "Other",
+      "item": "V46B4Xy1PeQ",
+      "parts": [
+        "V46B4Xy1PeQ"
+      ],
+      "has_transcript": false
     },
     {
       "path": "data/video/activeinferenceinstitute/Other/VTivWre-8Kk",

--- a/INDEX.md
+++ b/INDEX.md
@@ -1,6 +1,6 @@
 # ActiveInferenceJournal — Index
 
-573 items · 740 video records · 19 series · 736 unique video IDs. Root: `data/video/activeinferenceinstitute/`. Machine index: `INDEX.json`.
+579 items · 746 video records · 19 series · 742 unique video IDs. Root: `data/video/activeinferenceinstitute/`. Machine index: `INDEX.json`.
 
 ## ActiveInferAntStream (17)
 - ✓ [`ActiveInferAntStream_001`](data/video/activeinferenceinstitute/ActiveInferAntStream/ActiveInferAntStream_001/) — 2 video record(s)
@@ -55,7 +55,7 @@
 - ✓ [`SocialConstraints_Lecture`](data/video/activeinferenceinstitute/Courses/ActiveInferenceForTheSocialSciences/SocialConstraints_Lecture/) — 1 video record(s)
 - ✓ [`PhysicsAsInformationProcessing_ChrisFields`](data/video/activeinferenceinstitute/Courses/PhysicsAsInformationProcessing_ChrisFields/) — 11 video record(s)
 
-## GuestStream (126)
+## GuestStream (127)
 - ✓ [`GuestStream_001`](data/video/activeinferenceinstitute/GuestStream/GuestStream_001/) — 1 video record(s)
 - ✓ [`GuestStream_002`](data/video/activeinferenceinstitute/GuestStream/GuestStream_002/) — 1 video record(s)
 - ✓ [`GuestStream_003`](data/video/activeinferenceinstitute/GuestStream/GuestStream_003/) — 1 video record(s)
@@ -182,6 +182,7 @@
 - ✓ [`GuestStream_125`](data/video/activeinferenceinstitute/GuestStream/GuestStream_125/) — 1 video record(s)
 - ✓ [`GuestStream_126`](data/video/activeinferenceinstitute/GuestStream/GuestStream_126/) — 1 video record(s)
 - ✓ [`GuestStream_127`](data/video/activeinferenceinstitute/GuestStream/GuestStream_127/) — 1 video record(s)
+- · [`GuestStream_128`](data/video/activeinferenceinstitute/GuestStream/GuestStream_128/) — 1 video record(s)
 
 ## Insights (24)
 - ✓ [`Insights_001`](data/video/activeinferenceinstitute/Insights/Insights_001/) — 1 video record(s)
@@ -332,7 +333,7 @@
 - ✓ [`OrgStream_008`](data/video/activeinferenceinstitute/OrgStream/OrgStream_008/) — 1 video record(s)
 - ✓ [`OrgStream_009`](data/video/activeinferenceinstitute/OrgStream/OrgStream_009/) — 1 video record(s)
 
-## Other (85)
+## Other (90)
 - ✓ [`-39CESDAfLM`](data/video/activeinferenceinstitute/Other/-39CESDAfLM/) — 1 video record(s)
 - ✓ [`0A36OXIDLhQ`](data/video/activeinferenceinstitute/Other/0A36OXIDLhQ/) — 1 video record(s)
 - ✓ [`1ZJBJGzOn0g`](data/video/activeinferenceinstitute/Other/1ZJBJGzOn0g/) — 1 video record(s)
@@ -353,6 +354,8 @@
 - ✓ [`Ei8LHRlmbzI`](data/video/activeinferenceinstitute/Other/Ei8LHRlmbzI/) — 1 video record(s)
 - ✓ [`EkYlOX-f9sk`](data/video/activeinferenceinstitute/Other/EkYlOX-f9sk/) — 1 video record(s)
 - ✓ [`FlZa_odQymU`](data/video/activeinferenceinstitute/Other/FlZa_odQymU/) — 1 video record(s)
+- · [`FnYCaCkah4U`](data/video/activeinferenceinstitute/Other/FnYCaCkah4U/) — 1 video record(s)
+- · [`FtGnkRJwk6U`](data/video/activeinferenceinstitute/Other/FtGnkRJwk6U/) — 1 video record(s)
 - ✓ [`GMqkygROLO4`](data/video/activeinferenceinstitute/Other/GMqkygROLO4/) — 1 video record(s)
 - ✓ [`G_Jksni5o8I`](data/video/activeinferenceinstitute/Other/G_Jksni5o8I/) — 1 video record(s)
 - ✓ [`JkORFoyk8o8`](data/video/activeinferenceinstitute/Other/JkORFoyk8o8/) — 1 video record(s)
@@ -360,11 +363,13 @@
 - ✓ [`KR9KCKQ-KJo`](data/video/activeinferenceinstitute/Other/KR9KCKQ-KJo/) — 1 video record(s)
 - ✓ [`LI_ZIXys1xU`](data/video/activeinferenceinstitute/Other/LI_ZIXys1xU/) — 1 video record(s)
 - ✓ [`MRTULbP1ZKs`](data/video/activeinferenceinstitute/Other/MRTULbP1ZKs/) — 1 video record(s)
+- · [`MjeQeWeyYhE`](data/video/activeinferenceinstitute/Other/MjeQeWeyYhE/) — 1 video record(s)
 - ✓ [`OCCIDeeKOMA`](data/video/activeinferenceinstitute/Other/OCCIDeeKOMA/) — 1 video record(s)
 - ✓ [`P3h51-J4g8M`](data/video/activeinferenceinstitute/Other/P3h51-J4g8M/) — 1 video record(s)
 - ✓ [`PVeyvHSAwmk`](data/video/activeinferenceinstitute/Other/PVeyvHSAwmk/) — 1 video record(s) — duplicate of `Applied Active Inference Symposium/2023 Ecosystem Symposium/Second_Interval`
 - ✓ [`QmVuId8SY8k`](data/video/activeinferenceinstitute/Other/QmVuId8SY8k/) — 1 video record(s)
 - ✓ [`RDDfKm4yQIo`](data/video/activeinferenceinstitute/Other/RDDfKm4yQIo/) — 1 video record(s)
+- · [`SBCl8DeaJYU`](data/video/activeinferenceinstitute/Other/SBCl8DeaJYU/) — 1 video record(s)
 - ✓ [`TOZp_XNYijQ`](data/video/activeinferenceinstitute/Other/TOZp_XNYijQ/) — 1 video record(s)
 - ✓ [`TaFwI2zr_lE`](data/video/activeinferenceinstitute/Other/TaFwI2zr_lE/) — 1 video record(s)
 - ✓ [`TsQQX3ZdEmA`](data/video/activeinferenceinstitute/Other/TsQQX3ZdEmA/) — 1 video record(s)
@@ -372,6 +377,7 @@
 - ✓ [`U6Edc13EQ_k`](data/video/activeinferenceinstitute/Other/U6Edc13EQ_k/) — 1 video record(s)
 - ✓ [`UQGvfgp0bq4`](data/video/activeinferenceinstitute/Other/UQGvfgp0bq4/) — 1 video record(s)
 - ✓ [`UYD8CR_Xorg`](data/video/activeinferenceinstitute/Other/UYD8CR_Xorg/) — 1 video record(s)
+- · [`V46B4Xy1PeQ`](data/video/activeinferenceinstitute/Other/V46B4Xy1PeQ/) — 1 video record(s)
 - ✓ [`VTivWre-8Kk`](data/video/activeinferenceinstitute/Other/VTivWre-8Kk/) — 1 video record(s)
 - ✓ [`WkWIqpxWRM4`](data/video/activeinferenceinstitute/Other/WkWIqpxWRM4/) — 1 video record(s)
 - ✓ [`WxTOeCnQNmY`](data/video/activeinferenceinstitute/Other/WxTOeCnQNmY/) — 1 video record(s)

--- a/data/video/activeinferenceinstitute/Applied Active Inference Symposium/2023 Ecosystem Symposium/First_Interval/metadata.json
+++ b/data/video/activeinferenceinstitute/Applied Active Inference Symposium/2023 Ecosystem Symposium/First_Interval/metadata.json
@@ -28,8 +28,7 @@
     {
       "video_id": "rIemcswLfGg",
       "url": "https://www.youtube.com/watch?v=rIemcswLfGg",
-      "title": "3rd Applied Active Inference Symposium ~ \"Enacting Ecosystems of Shared Intelligence\" ~ 1st session",
-      "duration": 19736.0
+      "title": "3rd Applied Active Inference Symposium ~ \"Enacting Ecosystems of Shared Intelligence\" ~ 1st session"
     }
   ],
   "sessions": [

--- a/data/video/activeinferenceinstitute/Applied Active Inference Symposium/2023 Ecosystem Symposium/Second_Interval/metadata.json
+++ b/data/video/activeinferenceinstitute/Applied Active Inference Symposium/2023 Ecosystem Symposium/Second_Interval/metadata.json
@@ -33,8 +33,7 @@
     {
       "video_id": "PVeyvHSAwmk",
       "url": "https://www.youtube.com/watch?v=PVeyvHSAwmk",
-      "title": "3rd Applied Active Inference Symposium ~ \"Enacting Ecosystems of Shared Intelligence\" ~ 2nd session",
-      "duration": 23595.0
+      "title": "3rd Applied Active Inference Symposium ~ \"Enacting Ecosystems of Shared Intelligence\" ~ 2nd session"
     }
   ],
   "sessions": [

--- a/data/video/activeinferenceinstitute/GuestStream/GuestStream_128/README.md
+++ b/data/video/activeinferenceinstitute/GuestStream/GuestStream_128/README.md
@@ -1,0 +1,5 @@
+# GuestStream_128
+
+Series: **GuestStream**
+
+- [ActInf GuestStream 128.1: Active Inference as the Test-Time Scaling Law for Physical AI Agents](https://www.youtube.com/watch?v=vjtYYbO9jCY) — `vjtYYbO9jCY`

--- a/data/video/activeinferenceinstitute/GuestStream/GuestStream_128/metadata.json
+++ b/data/video/activeinferenceinstitute/GuestStream/GuestStream_128/metadata.json
@@ -1,0 +1,31 @@
+{
+  "series": "GuestStream",
+  "item": "GuestStream_128",
+  "source": "youtube",
+  "channel": "ActiveInferenceInstitute",
+  "category": "GuestStream",
+  "episode": "1",
+  "title": "GuestStream #128.1 ~ Active Inference as the Test-Time Scaling Law for Physical AI Agents",
+  "date": "2026-07-14",
+  "guests": [
+    "Omar Hashash",
+    "Christo Kurisummoottil Thomas"
+  ],
+  "other_participants": [
+    "Daniel Friedman"
+  ],
+  "github": "https://github.com/ActiveInferenceInstitute/ActiveInferenceJournal/tree/main/data/video/activeinferenceinstitute/GuestStream/GuestStream_128",
+  "enriched_from": [
+    "coda",
+    "generated"
+  ],
+  "parts": [
+    {
+      "video_id": "vjtYYbO9jCY",
+      "url": "https://www.youtube.com/watch?v=vjtYYbO9jCY",
+      "title": "ActInf GuestStream 128.1: Active Inference as the Test-Time Scaling Law for Physical AI Agents",
+      "duration": null,
+      "upload_date": ""
+    }
+  ]
+}

--- a/data/video/activeinferenceinstitute/Other/FnYCaCkah4U/README.md
+++ b/data/video/activeinferenceinstitute/Other/FnYCaCkah4U/README.md
@@ -1,0 +1,5 @@
+# FnYCaCkah4U
+
+Series: **Other**
+
+- [Fundamentals of Active Inference (Part 1 review, Session 26) July 10, 2026](https://www.youtube.com/watch?v=FnYCaCkah4U) — `FnYCaCkah4U`

--- a/data/video/activeinferenceinstitute/Other/FnYCaCkah4U/metadata.json
+++ b/data/video/activeinferenceinstitute/Other/FnYCaCkah4U/metadata.json
@@ -1,0 +1,21 @@
+{
+  "series": "Other",
+  "item": "FnYCaCkah4U",
+  "source": "youtube",
+  "channel": "ActiveInferenceInstitute",
+  "category": null,
+  "episode": null,
+  "github": "https://github.com/ActiveInferenceInstitute/ActiveInferenceJournal/tree/main/data/video/activeinferenceinstitute/Other/FnYCaCkah4U",
+  "enriched_from": [
+    "generated"
+  ],
+  "parts": [
+    {
+      "video_id": "FnYCaCkah4U",
+      "url": "https://www.youtube.com/watch?v=FnYCaCkah4U",
+      "title": "Fundamentals of Active Inference (Part 1 review, Session 26) July 10, 2026",
+      "duration": null,
+      "upload_date": ""
+    }
+  ]
+}

--- a/data/video/activeinferenceinstitute/Other/FtGnkRJwk6U/README.md
+++ b/data/video/activeinferenceinstitute/Other/FtGnkRJwk6U/README.md
@@ -1,0 +1,5 @@
+# FtGnkRJwk6U
+
+Series: **Other**
+
+- [Fundamentals of Active Inference (Part 1 review, Session 24) July 3, 2026](https://www.youtube.com/watch?v=FtGnkRJwk6U) — `FtGnkRJwk6U`

--- a/data/video/activeinferenceinstitute/Other/FtGnkRJwk6U/metadata.json
+++ b/data/video/activeinferenceinstitute/Other/FtGnkRJwk6U/metadata.json
@@ -1,0 +1,21 @@
+{
+  "series": "Other",
+  "item": "FtGnkRJwk6U",
+  "source": "youtube",
+  "channel": "ActiveInferenceInstitute",
+  "category": null,
+  "episode": null,
+  "github": "https://github.com/ActiveInferenceInstitute/ActiveInferenceJournal/tree/main/data/video/activeinferenceinstitute/Other/FtGnkRJwk6U",
+  "enriched_from": [
+    "generated"
+  ],
+  "parts": [
+    {
+      "video_id": "FtGnkRJwk6U",
+      "url": "https://www.youtube.com/watch?v=FtGnkRJwk6U",
+      "title": "Fundamentals of Active Inference (Part 1 review, Session 24) July 3, 2026",
+      "duration": null,
+      "upload_date": ""
+    }
+  ]
+}

--- a/data/video/activeinferenceinstitute/Other/MjeQeWeyYhE/README.md
+++ b/data/video/activeinferenceinstitute/Other/MjeQeWeyYhE/README.md
@@ -1,0 +1,5 @@
+# MjeQeWeyYhE
+
+Series: **Other**
+
+- [Fundamentals of Active Inference (Part 1 review, Session 23) June 30, 2026](https://www.youtube.com/watch?v=MjeQeWeyYhE) — `MjeQeWeyYhE`

--- a/data/video/activeinferenceinstitute/Other/MjeQeWeyYhE/metadata.json
+++ b/data/video/activeinferenceinstitute/Other/MjeQeWeyYhE/metadata.json
@@ -1,0 +1,21 @@
+{
+  "series": "Other",
+  "item": "MjeQeWeyYhE",
+  "source": "youtube",
+  "channel": "ActiveInferenceInstitute",
+  "category": null,
+  "episode": null,
+  "github": "https://github.com/ActiveInferenceInstitute/ActiveInferenceJournal/tree/main/data/video/activeinferenceinstitute/Other/MjeQeWeyYhE",
+  "enriched_from": [
+    "generated"
+  ],
+  "parts": [
+    {
+      "video_id": "MjeQeWeyYhE",
+      "url": "https://www.youtube.com/watch?v=MjeQeWeyYhE",
+      "title": "Fundamentals of Active Inference (Part 1 review, Session 23) June 30, 2026",
+      "duration": null,
+      "upload_date": ""
+    }
+  ]
+}

--- a/data/video/activeinferenceinstitute/Other/SBCl8DeaJYU/README.md
+++ b/data/video/activeinferenceinstitute/Other/SBCl8DeaJYU/README.md
@@ -1,0 +1,5 @@
+# SBCl8DeaJYU
+
+Series: **Other**
+
+- [Fundamentals of Active Inference (Chapter 6 Session 27) July 14, 2026](https://www.youtube.com/watch?v=SBCl8DeaJYU) — `SBCl8DeaJYU`

--- a/data/video/activeinferenceinstitute/Other/SBCl8DeaJYU/metadata.json
+++ b/data/video/activeinferenceinstitute/Other/SBCl8DeaJYU/metadata.json
@@ -1,0 +1,21 @@
+{
+  "series": "Other",
+  "item": "SBCl8DeaJYU",
+  "source": "youtube",
+  "channel": "ActiveInferenceInstitute",
+  "category": null,
+  "episode": null,
+  "github": "https://github.com/ActiveInferenceInstitute/ActiveInferenceJournal/tree/main/data/video/activeinferenceinstitute/Other/SBCl8DeaJYU",
+  "enriched_from": [
+    "generated"
+  ],
+  "parts": [
+    {
+      "video_id": "SBCl8DeaJYU",
+      "url": "https://www.youtube.com/watch?v=SBCl8DeaJYU",
+      "title": "Fundamentals of Active Inference (Chapter 6 Session 27) July 14, 2026",
+      "duration": null,
+      "upload_date": ""
+    }
+  ]
+}

--- a/data/video/activeinferenceinstitute/Other/V46B4Xy1PeQ/README.md
+++ b/data/video/activeinferenceinstitute/Other/V46B4Xy1PeQ/README.md
@@ -1,0 +1,5 @@
+# V46B4Xy1PeQ
+
+Series: **Other**
+
+- [Fundamentals of Active Inference (Coding + Agents, Session 25) July 7, 2026](https://www.youtube.com/watch?v=V46B4Xy1PeQ) — `V46B4Xy1PeQ`

--- a/data/video/activeinferenceinstitute/Other/V46B4Xy1PeQ/metadata.json
+++ b/data/video/activeinferenceinstitute/Other/V46B4Xy1PeQ/metadata.json
@@ -1,0 +1,21 @@
+{
+  "series": "Other",
+  "item": "V46B4Xy1PeQ",
+  "source": "youtube",
+  "channel": "ActiveInferenceInstitute",
+  "category": null,
+  "episode": null,
+  "github": "https://github.com/ActiveInferenceInstitute/ActiveInferenceJournal/tree/main/data/video/activeinferenceinstitute/Other/V46B4Xy1PeQ",
+  "enriched_from": [
+    "generated"
+  ],
+  "parts": [
+    {
+      "video_id": "V46B4Xy1PeQ",
+      "url": "https://www.youtube.com/watch?v=V46B4Xy1PeQ",
+      "title": "Fundamentals of Active Inference (Coding + Agents, Session 25) July 7, 2026",
+      "duration": null,
+      "upload_date": ""
+    }
+  ]
+}


### PR DESCRIPTION
Channel re-enumeration: 729 → 735 public videos. New items: 5 Fundamentals of Active Inference course sessions (`Other/`) + `GuestStream/GuestStream_128` (whose Coda row now matches — 644/694 matched by id). Generated via the uncovered pass, enriched, indexes regenerated, `validate_journal` PASS, idempotent.

Notes:
- The 2025 5th Symposium uploads are **unlisted**, not on the public channel tabs — they belong in `private_videos.json` rather than the corpus.
- `--strict-manifest` validation (non-CI mode) surfaces 7 pre-existing stray ids — 2 filename-fragment junk ids (`boost_gs062` in GuestStream_062, `transcripts` in PhysicsAsInformationProcessing) and 5 likely-unlisted videos; logged in QUESTIONS.md for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NjFiMWkgrVy4foGF1Zbax